### PR TITLE
feat: expose last bucket endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,17 @@
   },
   "devDependencies": {
     "vercel": "^43.0.0"
+  },
+  "env": {
+    "PIPELINE_ATENDIMENTO": "",
+    "STAGE_BUCKET": "",
+    "DEAL_ID_VALOR_IMOVEL": "",
+    "DEAL_ID_PRIMEIRA_PARCELA": "",
+    "DEAL_ID_VALOR_NMR_PARCELA": "",
+    "DEAL_ID_VALOR_SOLICITADO": "",
+    "DEAL_ID_CIDADE": "",
+    "DEAL_ID_PROPRIETARIO": "",
+    "DEAL_ID_AMORTIZACAO": "",
+    "DEAL_ID_LINKORIGEM": ""
   }
 }

--- a/src/api/APIChamadas.js
+++ b/src/api/APIChamadas.js
@@ -4,6 +4,31 @@ import dotenv from 'dotenv'; // responsável por armazenar as variáveis de ambi
 
 dotenv.config();
 
+export async function getLastDealByStage(pipelineId, stageId) {
+    try {
+        const response = await apiPloomes.get(
+            `/Deals?$filter=PipelineId eq ${pipelineId} and StageId eq ${stageId}` +
+            `&$orderby=StartDate desc&$top=1&$expand=Contact,OtherProperties`,
+            {
+                headers: {
+                    'Content-Type': 'application/json',
+                    'User-Key': process.env.PLOOMES_ID,
+                },
+            }
+        );
+
+        const deals = response.data.value;
+        return deals && deals.length ? deals[0] : null;
+    } catch (error) {
+        if (error.response) {
+            console.error('Erro API: ', error.response.data);
+        } else {
+            console.error('Erro geral: ', error.message);
+        }
+        throw error;
+    }
+}
+
 export class CallOptions{
     constructor(){}
 

--- a/src/routes/RotasOnline.js
+++ b/src/routes/RotasOnline.js
@@ -4,5 +4,9 @@ import CadastroControllers from "../Controllers/CadastroControllersOnline.js";
 const router = new Router();
 
 router.post('/env/', CadastroControllers.store.bind(CadastroControllers));
+router.get(
+  '/bucket/last',
+  CadastroControllers.showLastBucket.bind(CadastroControllers)
+);
 
 export default router;


### PR DESCRIPTION
## Summary
- add utility to fetch last deal from specific pipeline stage
- expose GET /cadastro/online/bucket/last to return client and simulation data
- document required environment variables

## Testing
- `npm test` *(fails: Error: no test specified)*
- `curl -i http://localhost:3063/cadastro/online/bucket/last` *(connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c18ce9b8c88320a1e345565ba70db0